### PR TITLE
Added ability to fetch without authentication

### DIFF
--- a/src/api/capabilities.rs
+++ b/src/api/capabilities.rs
@@ -1,6 +1,7 @@
 use crate::types;
 use crate::Openstreetmap;
 use crate::OpenstreetmapError;
+use crate::RequestOptions;
 
 #[derive(Debug, Deserialize)]
 struct Osm {
@@ -97,9 +98,9 @@ impl Capabilities {
             .client
             .request::<(), Osm>(
                 reqwest::Method::GET,
-                None,
                 "capabilities",
                 types::RequestBody::None,
+                RequestOptions::new(),
             )
             .await?
             .into();

--- a/src/api/changeset.rs
+++ b/src/api/changeset.rs
@@ -1,6 +1,7 @@
 use crate::types;
 use crate::Openstreetmap;
 use crate::OpenstreetmapError;
+use crate::RequestOptions;
 
 #[derive(Debug, Serialize)]
 #[serde(rename = "changeset")]
@@ -73,9 +74,9 @@ impl Changeset {
             .client
             .request::<OsmCreate, u64>(
                 reqwest::Method::PUT,
-                Some(&self.client.api_version),
                 "changeset/create",
                 body,
+                RequestOptions::new().with_version().with_auth(),
             )
             .await?;
 
@@ -93,9 +94,9 @@ impl Changeset {
             .client
             .request::<OsmUpdate, Osm>(
                 reqwest::Method::PUT,
-                Some(&self.client.api_version),
                 &url,
                 body,
+                RequestOptions::new().with_version().with_auth(),
             )
             .await?
             .changeset;
@@ -129,10 +130,11 @@ impl Changeset {
 
         let changeset = self
             .client
-            .request_including_version::<(), Osm>(
+            .request::<(), Osm>(
                 reqwest::Method::GET,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version(),
             )
             .await?
             .changeset;
@@ -145,10 +147,11 @@ impl Changeset {
 
         // Use Vec<u8> because `serde` cannot deserialise EOF when using Unit;
         self.client
-            .request_including_version::<(), Vec<u8>>(
+            .request::<(), Vec<u8>>(
                 reqwest::Method::PUT,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version().with_auth(),
             )
             .await?;
 
@@ -163,10 +166,11 @@ impl Changeset {
 
         let changes = self
             .client
-            .request_including_version::<(), types::ChangesetChanges>(
+            .request::<(), types::ChangesetChanges>(
                 reqwest::Method::GET,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version(),
             )
             .await?;
 
@@ -182,10 +186,11 @@ impl Changeset {
 
         let diffs = self
             .client
-            .request_including_version::<types::ChangesetChanges, types::DiffResult>(
+            .request::<types::ChangesetChanges, types::DiffResult>(
                 reqwest::Method::POST,
                 &url,
                 types::RequestBody::Xml(changeset_change),
+                RequestOptions::new().with_version().with_auth(),
             )
             .await?;
 
@@ -202,7 +207,12 @@ impl Changeset {
 
         // Use Vec<u8> because `serde` cannot deserialise EOF when using Unit;
         self.client
-            .request_including_version::<Comment, Vec<u8>>(reqwest::Method::POST, &url, body)
+            .request::<Comment, Vec<u8>>(
+                reqwest::Method::POST,
+                &url,
+                body,
+                RequestOptions::new().with_version().with_auth(),
+            )
             .await?;
 
         Ok(())
@@ -216,10 +226,11 @@ impl Changeset {
 
         let changeset = self
             .client
-            .request_including_version::<(), Osm>(
+            .request::<(), Osm>(
                 reqwest::Method::POST,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version().with_auth(),
             )
             .await?
             .changeset;
@@ -235,10 +246,11 @@ impl Changeset {
 
         let changeset = self
             .client
-            .request_including_version::<(), Osm>(
+            .request::<(), Osm>(
                 reqwest::Method::POST,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version().with_auth(),
             )
             .await?
             .changeset;

--- a/src/api/changesets.rs
+++ b/src/api/changesets.rs
@@ -1,6 +1,7 @@
 use crate::types;
 use crate::Openstreetmap;
 use crate::OpenstreetmapError;
+use crate::RequestOptions;
 
 use serde::ser::Serializer;
 use std::fmt::Display;
@@ -92,10 +93,11 @@ impl Changesets {
 
         let changesets = self
             .client
-            .request_including_version::<(), Osm>(
+            .request::<(), Osm>(
                 reqwest::Method::GET,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version(),
             )
             .await?
             .changesets;

--- a/src/api/elements.rs
+++ b/src/api/elements.rs
@@ -1,6 +1,7 @@
 use crate::types;
 use crate::Openstreetmap;
 use crate::OpenstreetmapError;
+use crate::RequestOptions;
 
 use serde::de::{self, Deserialize, DeserializeOwned, Deserializer};
 use serde::ser::{Serialize, SerializeMap, Serializer};
@@ -433,7 +434,12 @@ impl<E: OpenstreetmapNode + Serialize + DeserializeOwned> Elements<E> {
 
         let element_id = self
             .client
-            .request_including_version::<OsmSingle<E>, u64>(reqwest::Method::PUT, &url, body)
+            .request::<OsmSingle<E>, u64>(
+                reqwest::Method::PUT,
+                &url,
+                body,
+                RequestOptions::new().with_version().with_auth(),
+            )
             .await?;
 
         Ok(element_id)
@@ -443,10 +449,11 @@ impl<E: OpenstreetmapNode + Serialize + DeserializeOwned> Elements<E> {
         let url = format!("{}{}", E::base_url(), element_id);
         let element = self
             .client
-            .request_including_version::<u64, OsmSingle<E>>(
+            .request::<u64, OsmSingle<E>>(
                 reqwest::Method::GET,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version(),
             )
             .await?
             .element;
@@ -460,7 +467,12 @@ impl<E: OpenstreetmapNode + Serialize + DeserializeOwned> Elements<E> {
 
         let version = self
             .client
-            .request_including_version::<OsmSingle<E>, u64>(reqwest::Method::PUT, &url, body)
+            .request::<OsmSingle<E>, u64>(
+                reqwest::Method::PUT,
+                &url,
+                body,
+                RequestOptions::new().with_version().with_auth(),
+            )
             .await?;
 
         Ok(version)
@@ -472,7 +484,12 @@ impl<E: OpenstreetmapNode + Serialize + DeserializeOwned> Elements<E> {
 
         let version = self
             .client
-            .request_including_version::<OsmSingle<E>, u64>(reqwest::Method::DELETE, &url, body)
+            .request::<OsmSingle<E>, u64>(
+                reqwest::Method::DELETE,
+                &url,
+                body,
+                RequestOptions::new().with_version().with_auth(),
+            )
             .await?;
 
         Ok(version)
@@ -482,10 +499,11 @@ impl<E: OpenstreetmapNode + Serialize + DeserializeOwned> Elements<E> {
         let url = format!("{}{}/history", E::base_url(), element_id);
         let elements = self
             .client
-            .request_including_version::<u64, OsmList<E>>(
+            .request::<u64, OsmList<E>>(
                 reqwest::Method::GET,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version(),
             )
             .await?
             .elements;
@@ -497,10 +515,11 @@ impl<E: OpenstreetmapNode + Serialize + DeserializeOwned> Elements<E> {
         let url = format!("{}{}/{}", E::base_url(), element_id, version_id);
         let element = self
             .client
-            .request_including_version::<u64, OsmSingle<E>>(
+            .request::<u64, OsmSingle<E>>(
                 reqwest::Method::GET,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version(),
             )
             .await?
             .element;
@@ -522,10 +541,11 @@ impl<E: OpenstreetmapNode + Serialize + DeserializeOwned> Elements<E> {
 
         let elements = self
             .client
-            .request_including_version::<u64, OsmList<E>>(
+            .request::<u64, OsmList<E>>(
                 reqwest::Method::GET,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version(),
             )
             .await?
             .elements;
@@ -540,10 +560,11 @@ impl<E: OpenstreetmapNode + Serialize + DeserializeOwned> Elements<E> {
         let url = format!("{}{}/relations", E::base_url(), element_id);
         let elements = self
             .client
-            .request_including_version::<u64, OsmList<types::Relation>>(
+            .request::<u64, OsmList<types::Relation>>(
                 reqwest::Method::GET,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version(),
             )
             .await?
             .elements;
@@ -557,10 +578,11 @@ impl Elements<types::Node> {
         let url = format!("node/{}/ways", node_id);
         let elements = self
             .client
-            .request_including_version::<u64, OsmList<types::Way>>(
+            .request::<u64, OsmList<types::Way>>(
                 reqwest::Method::GET,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version(),
             )
             .await?
             .elements;
@@ -574,10 +596,11 @@ impl Elements<types::Way> {
         let url = format!("way/{}/full", way_id);
         let full = self
             .client
-            .request_including_version::<u64, types::WayFull>(
+            .request::<u64, types::WayFull>(
                 reqwest::Method::GET,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version(),
             )
             .await?;
 
@@ -590,10 +613,11 @@ impl Elements<types::Relation> {
         let url = format!("relation/{}/full", relation_id);
         let full = self
             .client
-            .request_including_version::<u64, types::RelationFull>(
+            .request::<u64, types::RelationFull>(
                 reqwest::Method::GET,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version(),
             )
             .await?;
 

--- a/src/api/map.rs
+++ b/src/api/map.rs
@@ -1,6 +1,7 @@
 use crate::types;
 use crate::Openstreetmap;
 use crate::OpenstreetmapError;
+use crate::RequestOptions;
 
 #[derive(Debug, Deserialize)]
 struct Bounds {
@@ -61,10 +62,11 @@ impl Map {
         );
         let map = self
             .client
-            .request_including_version::<(), Osm>(
+            .request::<(), Osm>(
                 reqwest::Method::GET,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version(),
             )
             .await?
             .into();

--- a/src/api/notes.rs
+++ b/src/api/notes.rs
@@ -1,6 +1,7 @@
 use crate::errors::OpenstreetmapError;
 use crate::types;
 use crate::Openstreetmap;
+use crate::RequestOptions;
 
 #[derive(Debug, Default, PartialEq, Deserialize)]
 pub struct CommentsRaw {
@@ -72,10 +73,11 @@ impl Notes {
 
         let notes = self
             .client
-            .request_including_version::<(), OsmList>(
+            .request::<(), OsmList>(
                 reqwest::Method::GET,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version(),
             )
             .await?
             .notes
@@ -91,10 +93,11 @@ impl Notes {
 
         let note = self
             .client
-            .request_including_version::<(), OsmSingle>(
+            .request::<(), OsmSingle>(
                 reqwest::Method::GET,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version(),
             )
             .await?
             .note
@@ -109,10 +112,11 @@ impl Notes {
     ) -> Result<types::Note, OpenstreetmapError> {
         let note = self
             .client
-            .request_including_version::<types::NoteContent, OsmSingle>(
+            .request::<types::NoteContent, OsmSingle>(
                 reqwest::Method::POST,
                 "notes",
                 types::RequestBody::Form(note_content),
+                RequestOptions::new().with_version().with_auth(),
             )
             .await?
             .note

--- a/src/api/permissions.rs
+++ b/src/api/permissions.rs
@@ -1,6 +1,7 @@
 use crate::types;
 use crate::Openstreetmap;
 use crate::OpenstreetmapError;
+use crate::RequestOptions;
 
 #[derive(Debug, Deserialize)]
 struct InnerPermissions {
@@ -28,10 +29,11 @@ impl Permissions {
     pub async fn get(&self) -> Result<Vec<types::Permission>, OpenstreetmapError> {
         let permissions = self
             .client
-            .request_including_version::<(), Osm>(
+            .request::<(), Osm>(
                 reqwest::Method::GET,
                 "permissions",
                 types::RequestBody::None,
+                RequestOptions::new().with_version(),
             )
             .await?
             .inner_permissions

--- a/src/api/user.rs
+++ b/src/api/user.rs
@@ -1,6 +1,7 @@
 use crate::errors::OpenstreetmapError;
 use crate::types;
 use crate::Openstreetmap;
+use crate::RequestOptions;
 
 #[derive(Debug, PartialEq, Deserialize)]
 struct OsmSingle {
@@ -163,10 +164,11 @@ impl User {
 
         let user = self
             .client
-            .request_including_version::<(), OsmSingle>(
+            .request::<(), OsmSingle>(
                 reqwest::Method::GET,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version(),
             )
             .await?
             .user
@@ -186,10 +188,11 @@ impl User {
 
         let users = self
             .client
-            .request_including_version::<(), OsmList>(
+            .request::<(), OsmList>(
                 reqwest::Method::GET,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version(),
             )
             .await?
             .users
@@ -203,10 +206,11 @@ impl User {
     pub async fn details(&self) -> Result<types::User, OpenstreetmapError> {
         let user = self
             .client
-            .request_including_version::<(), OsmSingle>(
+            .request::<(), OsmSingle>(
                 reqwest::Method::GET,
                 "user/details",
                 types::RequestBody::None,
+                RequestOptions::new().with_version().with_auth(),
             )
             .await?
             .user
@@ -218,10 +222,11 @@ impl User {
     pub async fn preferences(&self) -> Result<types::UserPreferences, OpenstreetmapError> {
         let user = self
             .client
-            .request_including_version::<(), OsmPreferences>(
+            .request::<(), OsmPreferences>(
                 reqwest::Method::GET,
                 "user/preferences",
                 types::RequestBody::None,
+                RequestOptions::new().with_version().with_auth(),
             )
             .await?
             .into();
@@ -237,10 +242,11 @@ impl User {
 
         // Use Vec<u8> because `serde` cannot deserialise EOF when using Unit;
         self.client
-            .request_including_version::<OsmPreferences, Vec<u8>>(
+            .request::<OsmPreferences, Vec<u8>>(
                 reqwest::Method::PUT,
                 "user/preferences",
                 payload,
+                RequestOptions::new().with_version().with_auth(),
             )
             .await?;
 
@@ -252,10 +258,11 @@ impl User {
 
         let user = self
             .client
-            .request_including_version::<(), String>(
+            .request::<(), String>(
                 reqwest::Method::GET,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version().with_auth(),
             )
             .await?;
 
@@ -271,7 +278,12 @@ impl User {
         let payload = types::RequestBody::RawForm(value.into());
 
         self.client
-            .request_including_version::<String, Vec<u8>>(reqwest::Method::PUT, &url, payload)
+            .request::<String, Vec<u8>>(
+                reqwest::Method::PUT,
+                &url,
+                payload,
+                RequestOptions::new().with_version().with_auth(),
+            )
             .await?;
 
         Ok(())
@@ -282,10 +294,11 @@ impl User {
 
         // Use Vec<u8> because `serde` cannot deserialise EOF when using Unit;
         self.client
-            .request_including_version::<(), Vec<u8>>(
+            .request::<(), Vec<u8>>(
                 reqwest::Method::DELETE,
                 &url,
                 types::RequestBody::None,
+                RequestOptions::new().with_version().with_auth(),
             )
             .await?;
 

--- a/src/api/versions.rs
+++ b/src/api/versions.rs
@@ -1,6 +1,7 @@
 use crate::types;
 use crate::Openstreetmap;
 use crate::OpenstreetmapError;
+use crate::RequestOptions;
 
 #[derive(Debug, Deserialize)]
 struct Version {
@@ -30,9 +31,9 @@ impl Versions {
             .client
             .request::<(), Osm>(
                 reqwest::Method::GET,
-                None,
                 "versions",
                 types::RequestBody::None,
+                RequestOptions::new(),
             )
             .await?
             .versions

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,6 +29,9 @@ pub enum OpenstreetmapError {
 
     /// Page not found
     NotFound,
+
+    /// Missing credentials for operation that requires authentication
+    CredentialsNeeded,
 }
 
 impl error::Error for OpenstreetmapError {}

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,7 @@ use std::fmt;
 #[derive(Debug, Clone)]
 pub enum Credentials {
     Basic(String, String), // Username, password
+    None,
 }
 
 pub enum RequestBody<S: Serialize> {

--- a/tests/api/capabilities_test.rs
+++ b/tests/api/capabilities_test.rs
@@ -5,7 +5,7 @@ use rstest::*;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use super::utils::credentials;
+use super::utils::no_credentials;
 
 #[rstest(response_str, expected,
     case(
@@ -68,7 +68,7 @@ use super::utils::credentials;
 )]
 #[actix_rt::test]
 async fn test_get(
-    credentials: types::Credentials,
+    no_credentials: types::Credentials,
     response_str: &str,
     expected: types::CapabilitiesAndPolicy,
 ) {
@@ -87,7 +87,7 @@ async fn test_get(
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let actual = client.capabilities().await.unwrap();

--- a/tests/api/changeset_test.rs
+++ b/tests/api/changeset_test.rs
@@ -6,6 +6,7 @@ use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use super::utils::credentials;
+use super::utils::no_credentials;
 
 #[rstest(body, response_str, expected,
     case(
@@ -86,7 +87,11 @@ async fn test_create(
     )
 )]
 #[actix_rt::test]
-async fn test_get(credentials: types::Credentials, response_str: &str, expected: types::Changeset) {
+async fn test_get(
+    no_credentials: types::Credentials,
+    response_str: &str,
+    expected: types::Changeset,
+) {
     /*
     GIVEN an OSM client
     WHEN calling the get() function with a changeset ID
@@ -102,7 +107,7 @@ async fn test_get(credentials: types::Credentials, response_str: &str, expected:
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let actual = client.changeset().get(10).await.unwrap();
@@ -153,7 +158,7 @@ async fn test_get(credentials: types::Credentials, response_str: &str, expected:
 )]
 #[actix_rt::test]
 async fn test_get_with_discussion(
-    credentials: types::Credentials,
+    no_credentials: types::Credentials,
     response_str: &str,
     expected: types::Changeset,
 ) {
@@ -174,7 +179,7 @@ async fn test_get_with_discussion(
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let actual = client.changeset().get_with_discussion(10).await.unwrap();
@@ -315,7 +320,7 @@ async fn test_close(credentials: types::Credentials) {
 )]
 #[actix_rt::test]
 async fn test_download(
-    credentials: types::Credentials,
+    no_credentials: types::Credentials,
     response_str: &str,
     expected: types::ChangesetChanges,
 ) {
@@ -335,7 +340,7 @@ async fn test_download(
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let actual = client.changeset().download(10).await.unwrap();

--- a/tests/api/changesets_test.rs
+++ b/tests/api/changesets_test.rs
@@ -5,7 +5,7 @@ use rstest::*;
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use super::utils::credentials;
+use super::utils::no_credentials;
 
 #[fixture]
 fn response_str() -> String {
@@ -41,7 +41,7 @@ fn response_str() -> String {
 )]
 #[actix_rt::test]
 async fn test_get(
-    credentials: types::Credentials,
+    no_credentials: types::Credentials,
     response_str: String,
     expected: Vec<types::Changeset>,
 ) {
@@ -60,7 +60,7 @@ async fn test_get(
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let query = types::ChangesetQueryParams::default();
@@ -72,7 +72,7 @@ async fn test_get(
 
 #[rstest]
 #[actix_rt::test]
-async fn test_get_with_query(credentials: types::Credentials, response_str: String) {
+async fn test_get_with_query(no_credentials: types::Credentials, response_str: String) {
     /*
     GIVEN an OSM client
     WHEN calling the get() function with a non-default query
@@ -90,7 +90,7 @@ async fn test_get_with_query(credentials: types::Credentials, response_str: Stri
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let query = types::ChangesetQueryParams {

--- a/tests/api/elements_test.rs
+++ b/tests/api/elements_test.rs
@@ -6,6 +6,7 @@ use wiremock::matchers::{method, path, query_param, QueryParamExactMatcher};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use super::utils::credentials;
+use super::utils::no_credentials;
 
 #[rstest(node, response_str, expected,
     case(
@@ -88,7 +89,7 @@ async fn test_create_element(
 )]
 #[actix_rt::test]
 async fn test_get(
-    credentials: types::Credentials,
+    no_credentials: types::Credentials,
     element_id: u64,
     response_str: &str,
     expected: types::Node,
@@ -108,7 +109,7 @@ async fn test_get(
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let actual = client.nodes().get(element_id).await.unwrap();
@@ -250,7 +251,7 @@ async fn test_delete_element(
 )]
 #[actix_rt::test]
 async fn test_history(
-    credentials: types::Credentials,
+    no_credentials: types::Credentials,
     element_id: u64,
     response_str: &str,
     expected: Vec<types::Node>,
@@ -270,7 +271,7 @@ async fn test_history(
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let actual = client.nodes().history(element_id).await.unwrap();
@@ -309,7 +310,7 @@ async fn test_history(
 )]
 #[actix_rt::test]
 async fn test_version(
-    credentials: types::Credentials,
+    no_credentials: types::Credentials,
     element_id: u64,
     version_id: u64,
     response_str: &str,
@@ -330,7 +331,7 @@ async fn test_version(
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let actual = client
@@ -443,7 +444,7 @@ async fn test_version(
 )]
 #[actix_rt::test]
 async fn test_multi_get(
-    credentials: types::Credentials,
+    no_credentials: types::Credentials,
     element_id_params: Vec<types::ElementIdParam>,
     request_qs: QueryParamExactMatcher,
     response_str: &str,
@@ -464,7 +465,7 @@ async fn test_multi_get(
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let actual = client.nodes().multi_get(element_id_params).await.unwrap();
@@ -502,7 +503,7 @@ async fn test_multi_get(
 )]
 #[actix_rt::test]
 async fn test_relations(
-    credentials: types::Credentials,
+    no_credentials: types::Credentials,
     element_id: u64,
     response_str: &str,
     expected: Vec<types::Relation>,
@@ -522,7 +523,7 @@ async fn test_relations(
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let actual = client.nodes().relations(element_id).await.unwrap();
@@ -556,7 +557,7 @@ async fn test_relations(
 )]
 #[actix_rt::test]
 async fn test_ways(
-    credentials: types::Credentials,
+    no_credentials: types::Credentials,
     node_id: u64,
     response_str: &str,
     expected: Vec<types::Way>,
@@ -576,7 +577,7 @@ async fn test_ways(
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let actual = client.nodes().ways(node_id).await.unwrap();
@@ -623,7 +624,7 @@ async fn test_ways(
 )]
 #[actix_rt::test]
 async fn test_way_full(
-    credentials: types::Credentials,
+    no_credentials: types::Credentials,
     way_id: u64,
     response_str: &str,
     expected: types::WayFull,
@@ -643,7 +644,7 @@ async fn test_way_full(
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let actual = client.ways().full(way_id).await.unwrap();
@@ -708,7 +709,7 @@ async fn test_way_full(
 )]
 #[actix_rt::test]
 async fn test_relation_full(
-    credentials: types::Credentials,
+    no_credentials: types::Credentials,
     relation_id: u64,
     response_str: &str,
     expected: types::RelationFull,
@@ -728,7 +729,7 @@ async fn test_relation_full(
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let actual = client.relations().full(relation_id).await.unwrap();

--- a/tests/api/map_test.rs
+++ b/tests/api/map_test.rs
@@ -5,7 +5,7 @@ use rstest::*;
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use super::utils::credentials;
+use super::utils::no_credentials;
 
 #[rstest(response_str, expected,
     case(
@@ -117,7 +117,7 @@ use super::utils::credentials;
     )
 )]
 #[actix_rt::test]
-async fn test_get(credentials: types::Credentials, response_str: &str, expected: types::Map) {
+async fn test_get(no_credentials: types::Credentials, response_str: &str, expected: types::Map) {
     /*
     GIVEN an OSM client
     WHEN calling the map() function
@@ -134,7 +134,7 @@ async fn test_get(credentials: types::Credentials, response_str: &str, expected:
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
     let bbox = types::BoundingBox {
         left: 1.0,
         bottom: 2.0,

--- a/tests/api/notes_test.rs
+++ b/tests/api/notes_test.rs
@@ -5,6 +5,7 @@ use wiremock::matchers::{method, path, query_param, QueryParamExactMatcher};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use super::utils::credentials;
+use super::utils::no_credentials;
 
 #[fixture]
 fn note() -> types::Note {
@@ -74,7 +75,7 @@ fn note_response() -> &'static str {
 )]
 #[actix_rt::test]
 async fn test_get_by_bounding_box(
-    credentials: types::Credentials,
+    no_credentials: types::Credentials,
     bbox: types::BoundingBox,
     request_qs: QueryParamExactMatcher,
     note_response: &str,
@@ -95,7 +96,7 @@ async fn test_get_by_bounding_box(
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let actual = client.notes().get_by_bounding_box(&bbox).await.unwrap();
@@ -106,7 +107,7 @@ async fn test_get_by_bounding_box(
 
 #[rstest]
 #[actix_rt::test]
-async fn test_get(credentials: types::Credentials, note_response: &str, note: types::Note) {
+async fn test_get(no_credentials: types::Credentials, note_response: &str, note: types::Note) {
     /*
     GIVEN an OSM client
     WHEN calling the get() function
@@ -121,7 +122,7 @@ async fn test_get(credentials: types::Credentials, note_response: &str, note: ty
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let actual = client.notes().get(note.id).await.unwrap();

--- a/tests/api/permissions_test.rs
+++ b/tests/api/permissions_test.rs
@@ -5,7 +5,7 @@ use rstest::*;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use super::utils::credentials;
+use super::utils::no_credentials;
 
 #[rstest(response_str, expected,
     case(
@@ -33,7 +33,7 @@ use super::utils::credentials;
 )]
 #[actix_rt::test]
 async fn test_get(
-    credentials: types::Credentials,
+    no_credentials: types::Credentials,
     response_str: &str,
     expected: Vec<types::Permission>,
 ) {
@@ -52,7 +52,7 @@ async fn test_get(
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let actual = client.permissions().await.unwrap();

--- a/tests/api/user_test.rs
+++ b/tests/api/user_test.rs
@@ -6,6 +6,7 @@ use wiremock::matchers::{body_string, method, path, query_param, QueryParamExact
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use super::utils::credentials;
+use super::utils::no_credentials;
 
 #[rstest(user_id, response_str, expected,
     case(
@@ -41,7 +42,7 @@ use super::utils::credentials;
 )]
 #[actix_rt::test]
 async fn test_get(
-    credentials: types::Credentials,
+    no_credentials: types::Credentials,
     user_id: u64,
     response_str: &str,
     expected: types::User,
@@ -60,7 +61,7 @@ async fn test_get(
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let actual = client.user().get(user_id).await.unwrap();
@@ -104,7 +105,7 @@ async fn test_get(
 )]
 #[actix_rt::test]
 async fn test_users(
-    credentials: types::Credentials,
+    no_credentials: types::Credentials,
     user_ids: Vec<u64>,
     request_qs: QueryParamExactMatcher,
     response_str: &str,
@@ -125,7 +126,7 @@ async fn test_users(
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let actual = client.user().users(&user_ids).await.unwrap();

--- a/tests/api/utils/mod.rs
+++ b/tests/api/utils/mod.rs
@@ -6,3 +6,9 @@ use rstest::fixture;
 pub fn credentials() -> types::Credentials {
     types::Credentials::Basic("user".into(), "password".into())
 }
+
+#[fixture]
+#[inline]
+pub fn no_credentials() -> types::Credentials {
+    types::Credentials::None
+}

--- a/tests/api/versions_test.rs
+++ b/tests/api/versions_test.rs
@@ -4,7 +4,7 @@ use rstest::*;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use super::utils::credentials;
+use super::utils::no_credentials;
 
 #[rstest(response_str, expected,
     case(
@@ -19,7 +19,7 @@ use super::utils::credentials;
     )
 )]
 #[actix_rt::test]
-async fn test_get(credentials: types::Credentials, response_str: &str, expected: Vec<String>) {
+async fn test_get(no_credentials: types::Credentials, response_str: &str, expected: Vec<String>) {
     /*
     GIVEN an OSM client
     WHEN calling the versions() function
@@ -35,7 +35,7 @@ async fn test_get(credentials: types::Credentials, response_str: &str, expected:
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let actual = client.versions().await.unwrap();
@@ -58,7 +58,7 @@ async fn test_get(credentials: types::Credentials, response_str: &str, expected:
 )]
 #[actix_rt::test]
 async fn test_get_returns_unknown_version(
-    credentials: types::Credentials,
+    no_credentials: types::Credentials,
     response_str: &str,
     expected: Vec<String>,
 ) {
@@ -78,7 +78,7 @@ async fn test_get_returns_unknown_version(
         .mount(&mock_server)
         .await;
 
-    let client = Openstreetmap::new(mock_server.uri(), credentials);
+    let client = Openstreetmap::new(mock_server.uri(), no_credentials);
 
     // WHEN
     let actual = client.versions().await.unwrap();


### PR DESCRIPTION
By the [Openstreetmap API documentation](https://wiki.openstreetmap.org/wiki/API_v0.6#URL_.2B_authentication) "All of the calls to the API which update, create or delete data have to be made by an authenticated and authorized user.", which means that GET calls don't need authentication (except the one retrieving data of the current logged in user).

This PR modifies the GET request to not require authentication; also allows to create an instance of the client with no authentication whatsoever.